### PR TITLE
define application protocols in tls.Config

### DIFF
--- a/quic.go
+++ b/quic.go
@@ -43,6 +43,7 @@ func testQuic(ip string, config *ScanConfig, record *ScanRecord) bool {
 	tlsCfg := &tls.Config{
 		InsecureSkipVerify: true,
 		ServerName:         serverName,
+		NextProtos:         []string{"h3-29", "h3", "hq", "quic"},
 	}
 
 	ctx := context.TODO()


### PR DESCRIPTION
抱歉，没注意看 quic-go 的文档。这里说明必须加个应用协议，怪不得我一个 IP 都扫描不到。加了就可以了。

https://github.com/quic-go/quic-go/blob/v0.36.1/client.go#L107